### PR TITLE
feat: improve worker runtime testability and coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,19 +16,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/yamabiko
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/yamabiko_test
+      TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/yamabiko_test
 
     services:
       postgres:
         image: postgres:17-alpine
         env:
-          POSTGRES_DB: yamabiko
+          POSTGRES_DB: yamabiko_test
           POSTGRES_PASSWORD: postgres
           POSTGRES_USER: postgres
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U postgres -d yamabiko"
+          --health-cmd "pg_isready -U postgres -d yamabiko_test"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,23 @@ jobs:
     name: Lint & Test
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/yamabiko
+
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_DB: yamabiko
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d yamabiko"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
 
     steps:
       - uses: actions/checkout@v4
@@ -37,5 +54,13 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
-      - name: Test
-        run: pnpm test
+      - name: Coverage report
+        run: pnpm test:coverage
+
+      - name: Upload coverage
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: pnpm test:coverage
 
       - name: Upload coverage
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report

--- a/.sisyphus/plans/0002-implementation-plan.md
+++ b/.sisyphus/plans/0002-implementation-plan.md
@@ -163,5 +163,9 @@ This is the smallest slice that creates a real system boundary and unlocks queue
 - [x] Phase 1: webhook intake and normalization
 - [x] Phase 2: delivery/run persistence and queue handoff are implemented in the application flow
 - [ ] Phase 3: queue integration and worker orchestration
+- [ ] Phase 3.5: review context enrichment for bot and inline comments
+  - persist `commentId`, `reviewId`, `path`, `line`, and author type/bot metadata alongside review runs
+  - extend the GitHub adapter to fetch PR review comments in addition to webhook-triggered payloads
+  - make enriched review context the default input to Phase 4 policy evaluation
 - [ ] Phase 4: policy evaluation and suggestion path
 - [ ] Phase 5: deterministic apply path

--- a/.sisyphus/plans/0002-implementation-plan.md
+++ b/.sisyphus/plans/0002-implementation-plan.md
@@ -156,11 +156,12 @@ This is the smallest slice that creates a real system boundary and unlocks queue
 - `pnpm test`
 - route/integration tests with payload fixtures
 - schema and persistence behavior covered by automated tests
+- worker queue lifecycle integration tests when `DATABASE_URL` points to PostgreSQL
 
 ## Tracking Checklist
 
-- [ ] Phase 1: webhook intake and normalization
-- [ ] Phase 2: durable delivery and run persistence
+- [x] Phase 1: webhook intake and normalization
+- [x] Phase 2: delivery/run persistence and queue handoff are implemented in the application flow
 - [ ] Phase 3: queue integration and worker orchestration
 - [ ] Phase 4: policy evaluation and suggestion path
 - [ ] Phase 5: deterministic apply path

--- a/.sisyphus/plans/queue-worker.md
+++ b/.sisyphus/plans/queue-worker.md
@@ -37,7 +37,7 @@ Wire pg-boss into the existing queue adapter interface and implement a worker th
 
 - [x] **T4**: Create `PgBossReviewJobQueue` adapter
   - Implement `ReviewJobQueue.enqueue()` using pg-boss `send()`
-  - Add `createReviewQueue()` for queue creation with retry policy (retryLimit: 3, retryDelay: 30, retryBackoff: true)
+  - Add `createQueue()` for queue creation with retry policy (retryLimit: 3, retryDelay: 30, retryBackoff: true)
   - Add dead letter queue `review-jobs-dlq` for terminal failures
   - TDD: unit tests with pg-boss constructor injection (mockable)
   - Files: `src/adapters/queue/pg-boss-review-job-queue.ts`

--- a/.sisyphus/plans/queue-worker.md
+++ b/.sisyphus/plans/queue-worker.md
@@ -13,7 +13,7 @@ Wire pg-boss into the existing queue adapter interface and implement a worker th
 
 ### Wave 1: Domain Foundation (parallelizable: T1 ∥ T2)
 
-- [ ] **T1**: Add `RunStatus` to `ReviewRun` domain type
+- [x] **T1**: Add `RunStatus` to `ReviewRun` domain type
   - Define `RunStatus = "pending" | "processing" | "completed" | "failed" | "skipped"`
   - Add `status: RunStatus` field to `ReviewRun` interface
   - Add optional lifecycle fields: `startedAt?: string`, `completedAt?: string`, `errorMessage?: string`
@@ -21,21 +21,21 @@ Wire pg-boss into the existing queue adapter interface and implement a worker th
   - Update all existing tests that construct ReviewRun objects
   - Files: `src/domain/runs/review-run.ts`, `src/application/use-cases/ingest-review-event.ts`, existing tests
 
-- [ ] **T2**: Extend Drizzle schema with run lifecycle columns
+- [x] **T2**: Extend Drizzle schema with run lifecycle columns
   - Add columns to `review_runs` table: `status` (text, not null, default 'pending'), `started_at` (timestamp), `completed_at` (timestamp), `error_message` (text)
   - Create Drizzle migration for the schema change
   - Files: `src/adapters/persistence/schema.ts`, `drizzle/`
 
 ### Wave 2: Repository & Queue Adapter (depends on T1, T2)
 
-- [ ] **T3**: Extend `ReviewRunRepository` with lifecycle methods
+- [x] **T3**: Extend `ReviewRunRepository` with lifecycle methods
   - Add `updateStatus(id: string, status: RunStatus, metadata?: { startedAt?: string; completedAt?: string; errorMessage?: string }): Promise<void>`
   - Add `findByStatus(status: RunStatus): Promise<ReviewRun[]>`
   - Update `InMemoryReviewRunRepository` implementation
   - TDD: unit tests for new methods
   - Files: `src/adapters/persistence/review-run-repository.ts`, `src/adapters/persistence/in-memory-review-run-repository.ts`
 
-- [ ] **T4**: Create `PgBossReviewJobQueue` adapter
+- [x] **T4**: Create `PgBossReviewJobQueue` adapter
   - Implement `ReviewJobQueue.enqueue()` using pg-boss `send()`
   - Add `createReviewQueue()` for queue creation with retry policy (retryLimit: 3, retryDelay: 30, retryBackoff: true)
   - Add dead letter queue `review-jobs-dlq` for terminal failures
@@ -44,14 +44,14 @@ Wire pg-boss into the existing queue adapter interface and implement a worker th
 
 ### Wave 3: Worker Core (depends on T3, T4)
 
-- [ ] **T5**: Create failure classification module
+- [x] **T5**: Create failure classification module
   - Create `isRetryableError(error: unknown): boolean` function
   - Retryable: network errors (`ECONNREFUSED`, `ETIMEDOUT`), HTTP 5xx, rate limit (429)
   - Terminal: validation errors, missing run data, policy violations, programmer errors
   - TDD: unit tests for each error category
   - Files: `src/workers/failure-classification.ts`
 
-- [ ] **T6**: Create worker job handler
+- [x] **T6**: Create worker job handler
   - Create `handleReviewJob(deps, job): Promise<void>` function
   - Load run from `ReviewRunRepository.findById()`
   - Guard: run not found → terminal failure
@@ -63,7 +63,7 @@ Wire pg-boss into the existing queue adapter interface and implement a worker th
   - TDD: unit tests for all paths
   - Files: `src/workers/handle-review-job.ts`
 
-- [ ] **T7**: Add structured logging for job lifecycle
+- [x] **T7**: Add structured logging for job lifecycle
   - Create `createJobLogger(context: { runId, jobId })` factory
   - Log events: `job.received`, `job.processing`, `job.completed`, `job.failed`, `job.retrying`, `job.dead_lettered`
   - Include timing (duration), run ID, job ID, attempt number
@@ -73,7 +73,7 @@ Wire pg-boss into the existing queue adapter interface and implement a worker th
 
 ### Wave 4: Wiring & Integration (depends on T5, T6, T7)
 
-- [ ] **T8**: Implement worker entrypoint with pg-boss consumption
+- [x] **T8**: Implement worker entrypoint with pg-boss consumption
   - Replace heartbeat scaffold in `src/entrypoints/worker/main.ts`
   - Initialize pg-boss with DATABASE_URL from RuntimeConfig
   - Call `boss.start()`, `boss.createQueue()`, `boss.work()`
@@ -81,7 +81,7 @@ Wire pg-boss into the existing queue adapter interface and implement a worker th
   - Graceful shutdown: `boss.stop({ graceful: true, timeout: 30000 })` on SIGTERM/SIGINT
   - Files: `src/entrypoints/worker/main.ts`
 
-- [ ] **T9**: Integration tests for queue lifecycle
+- [x] **T9**: Integration tests for queue lifecycle
   - Test pg-boss enqueue → dequeue → handler execution
   - Test retry on retryable failure (job re-appears)
   - Test terminal failure → dead letter queue
@@ -91,10 +91,12 @@ Wire pg-boss into the existing queue adapter interface and implement a worker th
 
 ## Verification Criteria
 
-- [ ] F1: `pnpm test` — all tests pass (existing 48 + new)
-- [ ] F2: `pnpm lint` — zero errors
-- [ ] F3: No `any`, `@ts-ignore`, `@ts-expect-error`
+- [x] F1: `pnpm test` — all tests pass (existing 48 + new)
+- [x] F2: `pnpm lint` — zero errors
+- [x] F3: No `any`, `@ts-ignore`, `@ts-expect-error`
 - [ ] F4: Worker can consume a queued job end-to-end (manual or integration test)
+
+Note: `test/integration/workers/` is now present and runs when `DATABASE_URL` points to PostgreSQL. End-to-end verification still depends on a live Postgres runtime in CI or local development.
 
 ## Architecture Notes
 

--- a/README.md
+++ b/README.md
@@ -107,13 +107,19 @@ The initial webhook intake slice is implemented:
 - Idempotent delivery handling keyed by `X-GitHub-Delivery`
 - Review run creation with actionability classification and queue handoff for actionable events
 - pg-boss worker runtime with run status transitions, retry classification, stale-run recovery, and dead-letter handling
-- 95 tests in the suite, including worker integration tests that run when `DATABASE_URL` is set
+- 95 tests in the suite, including worker integration tests that run when `TEST_DATABASE_URL` is set
 
 Current runtime wiring is split:
 
 - `src/entrypoints/http/server.ts` still boots the HTTP server with in-memory adapters by default
 - `src/entrypoints/worker/main.ts` uses PostgreSQL + Drizzle + pg-boss
-- `test/integration/workers/` exercises the real worker path when a PostgreSQL `DATABASE_URL` is available (CI provides one)
+- `test/integration/workers/` exercises the real worker path when a PostgreSQL `TEST_DATABASE_URL` is available (CI provides one)
+
+The next planned slice is review context enrichment before GitHub write-back:
+
+- persist inline review comment context such as `commentId`, `reviewId`, `path`, `line`, and author type/bot metadata
+- extend the GitHub adapter so the worker can fetch PR review comments, not just react to webhook payloads
+- use that richer context as the input to Phase 4 policy evaluation and suggestion generation
 
 Phase 4 (policy evaluation and GitHub write-back) and Phase 5 (deterministic apply path) are still ahead.
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Phase 4 (policy evaluation and GitHub write-back) and Phase 5 (deterministic app
 
 ```bash
 pnpm install
-pnpm test       # unit tests + HTTP integration tests; worker integration tests run when DATABASE_URL is set
+pnpm test       # unit tests + HTTP integration tests; worker integration tests run when TEST_DATABASE_URL is set
 pnpm lint       # Biome formatting + ESLint type-aware checks
 ```
 
@@ -139,7 +139,7 @@ export WEBHOOK_SECRET="your-webhook-secret"
 pnpm dev
 ```
 
-> **Note:** `pnpm dev` starts the HTTP server with in-memory adapters. `pnpm dev:worker` and the worker integration tests require a PostgreSQL `DATABASE_URL`.
+> **Note:** `pnpm dev` starts the HTTP server with in-memory adapters. `pnpm dev:worker` requires a PostgreSQL `DATABASE_URL`, while the worker integration tests require a dedicated PostgreSQL `TEST_DATABASE_URL`.
 
 The test suite covers webhook HMAC signature verification, idempotent deduplication via `X-GitHub-Delivery`, event normalization for all supported GitHub event types, and queue/worker lifecycle with a real PostgreSQL-backed pg-boss runtime when enabled.
 

--- a/README.md
+++ b/README.md
@@ -100,19 +100,22 @@ Test naming:
 
 ## Status
 
-Phase 1+2 (webhook intake and event normalization) is implemented:
+The initial webhook intake slice is implemented:
 
-- POST /webhook endpoint with HMAC signature verification
+- POST `/webhook` with HMAC signature verification
 - Event normalization for `pull_request_review`, `pull_request_review_comment`, and `issue_comment`
 - Idempotent delivery handling keyed by `X-GitHub-Delivery`
-- Review run creation with actionability classification
-- Job queue handoff for actionable events
-- 48+ unit and integration tests
+- Review run creation with actionability classification and queue handoff for actionable events
+- pg-boss worker runtime with run status transitions, retry classification, stale-run recovery, and dead-letter handling
+- 95 tests in the suite, including worker integration tests that run when `DATABASE_URL` is set
 
-Current default runtime uses in-memory repositories in Phase 1+2.
-PostgreSQL-backed durable persistence is planned for Phase 4+.
+Current runtime wiring is split:
 
-Phase 3 (queue integration and worker orchestration) is in progress.
+- `src/entrypoints/http/server.ts` still boots the HTTP server with in-memory adapters by default
+- `src/entrypoints/worker/main.ts` uses PostgreSQL + Drizzle + pg-boss
+- `test/integration/workers/` exercises the real worker path when a PostgreSQL `DATABASE_URL` is available (CI provides one)
+
+Phase 4 (policy evaluation and GitHub write-back) and Phase 5 (deterministic apply path) are still ahead.
 
 ## Getting Started
 
@@ -125,7 +128,7 @@ Phase 3 (queue integration and worker orchestration) is in progress.
 
 ```bash
 pnpm install
-pnpm test       # 48+ unit and integration tests
+pnpm test       # unit tests + HTTP integration tests; worker integration tests run when DATABASE_URL is set
 pnpm lint       # Biome formatting + ESLint type-aware checks
 ```
 
@@ -136,9 +139,9 @@ export WEBHOOK_SECRET="your-webhook-secret"
 pnpm dev
 ```
 
-> **Note:** `DATABASE_URL` is not required for Phase 1+2 (in-memory repositories are used by default). It will be needed when PostgreSQL-backed persistence is added in Phase 4+.
+> **Note:** `pnpm dev` starts the HTTP server with in-memory adapters. `pnpm dev:worker` and the worker integration tests require a PostgreSQL `DATABASE_URL`.
 
-The test suite covers webhook HMAC signature verification, idempotent deduplication via `X-GitHub-Delivery`, and event normalization for all supported GitHub event types.
+The test suite covers webhook HMAC signature verification, idempotent deduplication via `X-GitHub-Delivery`, event normalization for all supported GitHub event types, and queue/worker lifecycle with a real PostgreSQL-backed pg-boss runtime when enabled.
 
 ## Planning
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "files": {
+    "includes": ["**", "!coverage"]
+  },
   "formatter": {
     "enabled": true,
     "indentStyle": "space"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "pnpm lint:biome && pnpm lint:eslint && pnpm typecheck",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "check": "pnpm lint && pnpm test",
     "simplify": "bash .sisyphus/scripts/simplify.sh"
@@ -36,6 +37,7 @@
     "@biomejs/biome": "^2.4.6",
     "@eslint/js": "^10.0.1",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^4.0.18",
     "drizzle-kit": "^0.31.9",
     "eslint": "^10.0.3",
     "globals": "^17.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
+      '@vitest/coverage-v8':
+        specifier: ^4.0.18
+        version: 4.0.18(vitest@4.0.18(@types/node@22.19.15)(tsx@4.21.0))
       drizzle-kit:
         specifier: ^0.31.9
         version: 0.31.9
@@ -65,6 +68,27 @@ importers:
         version: 4.0.18(@types/node@22.19.15)(tsx@4.21.0)
 
 packages:
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.0':
+    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@biomejs/biome@2.4.6':
     resolution: {integrity: sha512-QnHe81PMslpy3mnpL8DnO2M4S4ZnYPkjlGCLWBZT/3R9M6b5daArWMMtEfP52/n174RKnwRIf3oT8+wc9ihSfQ==}
@@ -647,8 +671,15 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@octokit/app@16.1.2':
     resolution: {integrity: sha512-8j7sEpUYVj18dxvh0KWj6W/l6uAiVRBl1JBDVRqH1VHKAO/G5eRVl4yEoYACjakWers1DjUkcCHyJNQK47JqyQ==}
@@ -968,6 +999,15 @@ packages:
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/coverage-v8@4.0.18':
+    resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
+    peerDependencies:
+      '@vitest/browser': 4.0.18
+      vitest: 4.0.18
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
 
@@ -1027,6 +1067,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
@@ -1330,6 +1373,13 @@ packages:
     resolution: {integrity: sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==}
     engines: {node: '>=18'}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1356,6 +1406,21 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -1449,6 +1514,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -1680,6 +1752,10 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
@@ -1850,6 +1926,21 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@2.4.6':
     optionalDependencies:
@@ -2188,7 +2279,14 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@octokit/app@16.1.2':
     dependencies:
@@ -2527,6 +2625,20 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@22.19.15)(tsx@4.21.0))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.18
+      ast-v8-to-istanbul: 0.3.12
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 3.10.0
+      tinyrainbow: 3.0.3
+      vitest: 4.0.18(@types/node@22.19.15)(tsx@4.21.0)
+
   '@vitest/expect@4.0.18':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2593,6 +2705,12 @@ snapshots:
       require-from-string: 2.0.2
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   atomic-sleep@1.0.0: {}
 
@@ -2898,6 +3016,10 @@ snapshots:
 
   globals@17.4.0: {}
 
+  has-flag@4.0.0: {}
+
+  html-escaper@2.0.2: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -2913,6 +3035,21 @@ snapshots:
       is-extglob: 2.1.1
 
   isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  js-tokens@10.0.0: {}
 
   json-buffer@3.0.1: {}
 
@@ -2995,6 +3132,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   minimatch@10.2.4:
     dependencies:
@@ -3228,6 +3375,10 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   tagged-tag@1.0.0: {}
 

--- a/src/adapters/queue/pg-boss-review-job-queue.ts
+++ b/src/adapters/queue/pg-boss-review-job-queue.ts
@@ -1,23 +1,46 @@
 import type { PgBoss } from "pg-boss";
-import type { ReviewJobQueue } from "../../application/ports/review-job-queue.js";
+import type {
+  ReviewJobQueue,
+  WorkerQueueSetup,
+} from "../../application/ports/review-job-queue.js";
 import type { ReviewJobPayload } from "../../contracts/review-job-payload.js";
 
 export const REVIEW_JOBS_QUEUE = "review-jobs";
 export const REVIEW_JOBS_DLQ = "review-jobs-dlq";
 
-export class PgBossReviewJobQueue implements ReviewJobQueue {
-  public constructor(private readonly boss: PgBoss) {}
+export interface ReviewJobQueueOptions {
+  retryLimit?: number;
+  retryDelay?: number;
+  retryBackoff?: boolean;
+}
+
+const DEFAULT_REVIEW_JOB_QUEUE_OPTIONS: Required<ReviewJobQueueOptions> = {
+  retryLimit: 3,
+  retryDelay: 30,
+  retryBackoff: true,
+};
+
+export class PgBossReviewJobQueue implements ReviewJobQueue, WorkerQueueSetup {
+  public constructor(
+    private readonly boss: PgBoss,
+    private readonly options?: ReviewJobQueueOptions,
+  ) {}
 
   public async enqueue(job: ReviewJobPayload): Promise<void> {
     await this.boss.send(REVIEW_JOBS_QUEUE, job);
   }
 
   public async createQueue(): Promise<void> {
+    const options: Required<ReviewJobQueueOptions> = {
+      ...DEFAULT_REVIEW_JOB_QUEUE_OPTIONS,
+      ...this.options,
+    };
+
     await this.boss.createQueue(REVIEW_JOBS_DLQ);
     await this.boss.createQueue(REVIEW_JOBS_QUEUE, {
-      retryLimit: 3,
-      retryDelay: 30,
-      retryBackoff: true,
+      retryLimit: options.retryLimit,
+      retryDelay: options.retryDelay,
+      retryBackoff: options.retryBackoff,
       deadLetter: REVIEW_JOBS_DLQ,
     });
   }

--- a/src/application/ports/review-job-queue.ts
+++ b/src/application/ports/review-job-queue.ts
@@ -3,3 +3,7 @@ import type { ReviewJobPayload } from "../../contracts/review-job-payload.js";
 export interface ReviewJobQueue {
   enqueue(job: ReviewJobPayload): Promise<void>;
 }
+
+export interface WorkerQueueSetup {
+  createQueue(): Promise<void>;
+}

--- a/src/entrypoints/worker/main.ts
+++ b/src/entrypoints/worker/main.ts
@@ -4,44 +4,11 @@ import { PgBoss } from "pg-boss";
 import { DrizzleReviewRunRepository } from "../../adapters/persistence/drizzle-review-run-repository.js";
 import {
   PgBossReviewJobQueue,
-  REVIEW_JOBS_DLQ,
   REVIEW_JOBS_QUEUE,
 } from "../../adapters/queue/pg-boss-review-job-queue.js";
-import type { ReviewRunRepository } from "../../application/ports/review-run-repository.js";
 import { loadWorkerConfig } from "../../config/env.js";
-import { reviewJobPayloadSchema } from "../../contracts/review-job-payload.js";
 import { StubFixExecutor } from "../../executors/stub-fix-executor.js";
-import { handleDeadLetter } from "../../workers/handle-dead-letter.js";
-import { handleReviewJob } from "../../workers/handle-review-job.js";
-import { createJobLogger } from "../../workers/job-logger.js";
-
-const STALE_PROCESSING_THRESHOLD_MS = 5 * 60 * 1000;
-
-async function recoverStaleRuns(
-  repository: ReviewRunRepository,
-): Promise<void> {
-  const processingRuns = await repository.findByStatus("processing");
-  const now = Date.now();
-
-  for (const run of processingRuns) {
-    if (run.startedAt === undefined) {
-      continue;
-    }
-
-    const elapsed = now - new Date(run.startedAt).getTime();
-    if (elapsed > STALE_PROCESSING_THRESHOLD_MS) {
-      const recovered = await repository.recoverStaleProcessing(
-        run.id,
-        run.startedAt,
-      );
-      if (recovered) {
-        console.log(
-          `Recovered stale processing run ${run.id} (stuck for ${String(Math.round(elapsed / 1000))}s)`,
-        );
-      }
-    }
-  }
-}
+import { startWorkerRuntime, stopWorkerRuntime } from "./run-worker.js";
 
 async function main(): Promise<void> {
   const config = loadWorkerConfig(process.env);
@@ -59,62 +26,14 @@ async function main(): Promise<void> {
   await boss.start();
 
   const queue = new PgBossReviewJobQueue(boss);
-  await queue.createQueue();
-
   const reviewRunRepository = new DrizzleReviewRunRepository(db);
   const fixExecutor = new StubFixExecutor();
 
-  await recoverStaleRuns(reviewRunRepository);
-
-  await boss.work(
-    REVIEW_JOBS_QUEUE,
-    { includeMetadata: true },
-    async (jobs) => {
-      for (const job of jobs) {
-        const parseResult = reviewJobPayloadSchema.safeParse(job.data);
-        if (!parseResult.success) {
-          throw new Error(
-            `Invalid job payload for job ${job.id}: ${parseResult.error.message}`,
-          );
-        }
-
-        const payload = parseResult.data;
-        const logger = createJobLogger({
-          attempt: job.retryCount + 1,
-          jobId: job.id,
-          runId: payload.runId,
-        });
-
-        await handleReviewJob(
-          {
-            reviewRunRepository,
-            fixExecutor,
-            logger,
-          },
-          payload,
-          job.retryCount,
-        );
-      }
-    },
-  );
-
-  await boss.work(REVIEW_JOBS_DLQ, async (jobs) => {
-    for (const job of jobs) {
-      const parseResult = reviewJobPayloadSchema.safeParse(job.data);
-      if (!parseResult.success) {
-        throw new Error(
-          `Invalid DLQ job payload for job ${job.id}: ${parseResult.error.message}`,
-        );
-      }
-
-      const payload = parseResult.data;
-      const logger = createJobLogger({
-        jobId: job.id,
-        runId: payload.runId,
-      });
-
-      await handleDeadLetter({ reviewRunRepository, logger }, payload);
-    }
+  await startWorkerRuntime({
+    boss,
+    fixExecutor,
+    queue,
+    reviewRunRepository,
   });
 
   console.log(
@@ -132,8 +51,7 @@ async function main(): Promise<void> {
     console.log(`${signal} received, shutting down worker...`);
 
     try {
-      await boss.stop({ graceful: true, timeout: 30_000 });
-      await pool.end();
+      await stopWorkerRuntime(boss, pool);
       process.exit(0);
     } catch (error) {
       console.error("Failed to stop pg-boss worker:", error);

--- a/src/entrypoints/worker/run-worker.ts
+++ b/src/entrypoints/worker/run-worker.ts
@@ -1,0 +1,152 @@
+import type { Pool } from "pg";
+import type { PgBoss } from "pg-boss";
+import {
+  REVIEW_JOBS_DLQ,
+  REVIEW_JOBS_QUEUE,
+} from "../../adapters/queue/pg-boss-review-job-queue.js";
+import type { FixExecutor } from "../../application/ports/fix-executor.js";
+import type { WorkerQueueSetup } from "../../application/ports/review-job-queue.js";
+import type { ReviewRunRepository } from "../../application/ports/review-run-repository.js";
+import { reviewJobPayloadSchema } from "../../contracts/review-job-payload.js";
+import { handleDeadLetter } from "../../workers/handle-dead-letter.js";
+import { handleReviewJob } from "../../workers/handle-review-job.js";
+import {
+  createJobLogger,
+  type JobLogContext,
+  type JobLogger,
+} from "../../workers/job-logger.js";
+
+export const STALE_PROCESSING_THRESHOLD_MS = 5 * 60 * 1000;
+
+export interface WorkerRuntimeDependencies {
+  boss: PgBoss;
+  fixExecutor: FixExecutor;
+  queue: WorkerQueueSetup;
+  reviewRunRepository: ReviewRunRepository;
+  createLogger?: (context: JobLogContext) => JobLogger;
+}
+
+export async function recoverStaleRuns(
+  repository: ReviewRunRepository,
+): Promise<void> {
+  const processingRuns = await repository.findByStatus("processing");
+  const now = Date.now();
+
+  for (const run of processingRuns) {
+    if (run.startedAt === undefined) {
+      continue;
+    }
+
+    const elapsed = now - new Date(run.startedAt).getTime();
+    if (elapsed > STALE_PROCESSING_THRESHOLD_MS) {
+      const recovered = await repository.recoverStaleProcessing(
+        run.id,
+        run.startedAt,
+      );
+      if (recovered) {
+        console.log(
+          `Recovered stale processing run ${run.id} (stuck for ${String(Math.round(elapsed / 1000))}s)`,
+        );
+      }
+    }
+  }
+}
+
+export async function startWorkerRuntime(
+  deps: WorkerRuntimeDependencies,
+): Promise<void> {
+  await deps.queue.createQueue();
+  await recoverStaleRuns(deps.reviewRunRepository);
+  await registerWorkerConsumers(deps);
+}
+
+export async function registerWorkerConsumers(
+  deps: WorkerRuntimeDependencies,
+): Promise<void> {
+  const createLogger = deps.createLogger ?? createJobLogger;
+
+  await deps.boss.work(
+    REVIEW_JOBS_QUEUE,
+    { includeMetadata: true },
+    async (jobs) => {
+      for (const job of jobs) {
+        const parseResult = reviewJobPayloadSchema.safeParse(job.data);
+        if (!parseResult.success) {
+          throw new Error(
+            `Invalid job payload for job ${job.id}: ${parseResult.error.message}`,
+          );
+        }
+
+        const payload = parseResult.data;
+        const logger = createLogger({
+          attempt: job.retryCount + 1,
+          jobId: job.id,
+          runId: payload.runId,
+        });
+
+        await handleReviewJob(
+          {
+            reviewRunRepository: deps.reviewRunRepository,
+            fixExecutor: deps.fixExecutor,
+            logger,
+          },
+          payload,
+          job.retryCount,
+        );
+      }
+    },
+  );
+
+  await deps.boss.work(REVIEW_JOBS_DLQ, async (jobs) => {
+    for (const job of jobs) {
+      const parseResult = reviewJobPayloadSchema.safeParse(job.data);
+      if (!parseResult.success) {
+        throw new Error(
+          `Invalid DLQ job payload for job ${job.id}: ${parseResult.error.message}`,
+        );
+      }
+
+      const payload = parseResult.data;
+      const logger = createLogger({
+        jobId: job.id,
+        runId: payload.runId,
+      });
+
+      await handleDeadLetter(
+        { reviewRunRepository: deps.reviewRunRepository, logger },
+        payload,
+      );
+    }
+  });
+}
+
+export async function stopWorkerRuntime(
+  boss: PgBoss,
+  pool: Pool,
+): Promise<void> {
+  let bossStopError: Error | undefined;
+
+  try {
+    await boss.stop({ graceful: true, timeout: 30_000 });
+  } catch (error) {
+    bossStopError = toError(error);
+  }
+
+  try {
+    await pool.end();
+  } catch (error) {
+    if (bossStopError !== undefined) {
+      console.error("Failed to close pg pool during worker shutdown:", error);
+    } else {
+      throw toError(error);
+    }
+  }
+
+  if (bossStopError !== undefined) {
+    throw bossStopError;
+  }
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/test/helpers/worker-test-runtime.ts
+++ b/test/helpers/worker-test-runtime.ts
@@ -115,18 +115,14 @@ export async function createWorkerTestRuntime(
 export async function waitForRun(
   repository: DrizzleReviewRunRepository,
   runId: string,
-  predicate: (run: FindReviewRunResult) => boolean,
+  predicate: (run: NonNullable<FindReviewRunResult>) => boolean,
   timeoutMs: number = 5_000,
 ): Promise<NonNullable<FindReviewRunResult>> {
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
     const run = await repository.findById(runId);
-    if (predicate(run)) {
-      if (run === null) {
-        throw new Error(`Expected run ${runId} to exist`);
-      }
-
+    if (run !== null && predicate(run)) {
       return run;
     }
 
@@ -166,11 +162,9 @@ async function runSqlStatements(client: Client, sql: string): Promise<void> {
         .split(statementBreakpoint)
         .map((statement) => statement.trim())
         .filter((statement) => statement.length > 0)
-    : sql
-        // TODO: Replace this semicolon fallback with a SQL-aware parser before adding custom migrations.
-        .split(";")
-        .map((statement) => statement.trim())
-        .filter((statement) => statement.length > 0);
+    : [sql.trim()].filter((statement) => statement.length > 0);
+
+  // TODO: Replace the single-statement fallback with a SQL-aware splitter before adding custom migrations.
 
   for (const statement of executableStatements) {
     await client.query(statement);

--- a/test/helpers/worker-test-runtime.ts
+++ b/test/helpers/worker-test-runtime.ts
@@ -45,6 +45,8 @@ type FindReviewRunResult = Awaited<
 export async function resetWorkerTestDatabase(
   connectionString: string,
 ): Promise<void> {
+  assertSafeTestDatabaseUrl(connectionString);
+
   const client = new pg.Client({ connectionString });
   await client.connect();
 
@@ -67,6 +69,8 @@ export async function createWorkerTestRuntime(
   fixExecutor: FixExecutor,
   queueOptions?: ReviewJobQueueOptions,
 ): Promise<WorkerTestRuntime> {
+  assertSafeTestDatabaseUrl(connectionString);
+
   const pool = new pg.Pool({ connectionString });
   const db = drizzle(pool);
   const boss = new PgBoss(connectionString);
@@ -172,6 +176,29 @@ async function findMigrationFiles(): Promise<string[]> {
     .filter((entry) => entry.isFile() && entry.name.endsWith(".sql"))
     .map((entry) => path.join(DRIZZLE_DIRECTORY, entry.name))
     .sort();
+}
+
+function assertSafeTestDatabaseUrl(connectionString: string): void {
+  if (process.env.TEST_DATABASE_URL === undefined) {
+    throw new Error(
+      "TEST_DATABASE_URL must be set for worker integration tests",
+    );
+  }
+
+  if (connectionString !== process.env.TEST_DATABASE_URL) {
+    throw new Error("Worker integration tests must use TEST_DATABASE_URL");
+  }
+
+  const parsed = new URL(connectionString);
+  const databaseName = parsed.pathname.replace(/^\//, "");
+  const isLocalhost =
+    parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1";
+
+  if (!isLocalhost || !databaseName.includes("test")) {
+    throw new Error(
+      `Unsafe worker test database target: ${parsed.hostname}/${databaseName}`,
+    );
+  }
 }
 
 function delay(ms: number): Promise<void> {

--- a/test/helpers/worker-test-runtime.ts
+++ b/test/helpers/worker-test-runtime.ts
@@ -1,0 +1,181 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { drizzle } from "drizzle-orm/node-postgres";
+import pg, { type Client } from "pg";
+import { PgBoss } from "pg-boss";
+import { DrizzleReviewRunRepository } from "../../src/adapters/persistence/drizzle-review-run-repository.js";
+import {
+  PgBossReviewJobQueue,
+  type ReviewJobQueueOptions,
+} from "../../src/adapters/queue/pg-boss-review-job-queue.js";
+import type { FixExecutor } from "../../src/application/ports/fix-executor.js";
+import {
+  startWorkerRuntime,
+  stopWorkerRuntime,
+} from "../../src/entrypoints/worker/run-worker.js";
+import {
+  createJobLogger,
+  type JobLogEntry,
+} from "../../src/workers/job-logger.js";
+
+const APP_RESET_STATEMENTS = [
+  'DROP TABLE IF EXISTS "idempotency_keys" CASCADE',
+  'DROP TABLE IF EXISTS "review_runs" CASCADE',
+  'DROP TABLE IF EXISTS "webhook_deliveries" CASCADE',
+  'DROP TYPE IF EXISTS "public"."review_actionability" CASCADE',
+  'DROP TYPE IF EXISTS "public"."run_mode" CASCADE',
+  'DROP TYPE IF EXISTS "public"."run_status" CASCADE',
+  "DROP SCHEMA IF EXISTS pgboss CASCADE",
+] as const;
+
+const DRIZZLE_DIRECTORY = path.resolve(process.cwd(), "drizzle");
+
+export interface WorkerTestRuntime {
+  boss: PgBoss;
+  logEntries: JobLogEntry[];
+  queue: PgBossReviewJobQueue;
+  reviewRunRepository: DrizzleReviewRunRepository;
+  stop(): Promise<void>;
+}
+
+type FindReviewRunResult = Awaited<
+  ReturnType<DrizzleReviewRunRepository["findById"]>
+>;
+
+export async function resetWorkerTestDatabase(
+  connectionString: string,
+): Promise<void> {
+  const client = new pg.Client({ connectionString });
+  await client.connect();
+
+  try {
+    for (const statement of APP_RESET_STATEMENTS) {
+      await client.query(statement);
+    }
+
+    for (const filePath of await findMigrationFiles()) {
+      const migrationSql = await readFile(filePath, "utf8");
+      await runSqlStatements(client, migrationSql);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+export async function createWorkerTestRuntime(
+  connectionString: string,
+  fixExecutor: FixExecutor,
+  queueOptions?: ReviewJobQueueOptions,
+): Promise<WorkerTestRuntime> {
+  const pool = new pg.Pool({ connectionString });
+  const db = drizzle(pool);
+  const boss = new PgBoss(connectionString);
+  const queue = new PgBossReviewJobQueue(boss, queueOptions);
+  const reviewRunRepository = new DrizzleReviewRunRepository(db);
+  const logEntries: JobLogEntry[] = [];
+
+  boss.on("error", (error) => {
+    console.error("pg-boss test error:", error);
+  });
+
+  try {
+    await boss.start();
+    await startWorkerRuntime({
+      boss,
+      createLogger: (context) =>
+        createJobLogger(context, (entry) => {
+          logEntries.push(entry);
+        }),
+      fixExecutor,
+      queue,
+      reviewRunRepository,
+    });
+  } catch (error) {
+    await stopWorkerRuntime(boss, pool).catch((shutdownError: unknown) => {
+      console.error("Failed to clean up worker test runtime:", shutdownError);
+    });
+    throw error instanceof Error ? error : new Error(String(error));
+  }
+
+  return {
+    boss,
+    logEntries,
+    queue,
+    reviewRunRepository,
+    async stop() {
+      await stopWorkerRuntime(boss, pool);
+    },
+  };
+}
+
+export async function waitForRun(
+  repository: DrizzleReviewRunRepository,
+  runId: string,
+  predicate: (run: FindReviewRunResult) => boolean,
+  timeoutMs: number = 5_000,
+): Promise<NonNullable<FindReviewRunResult>> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const run = await repository.findById(runId);
+    if (predicate(run)) {
+      if (run === null) {
+        throw new Error(`Expected run ${runId} to exist`);
+      }
+
+      return run;
+    }
+
+    await delay(50);
+  }
+
+  const latest = await repository.findById(runId);
+  throw new Error(
+    `Timed out waiting for run ${runId}. Latest state: ${JSON.stringify(latest)}`,
+  );
+}
+
+export async function waitForLogEntry(
+  logEntries: JobLogEntry[],
+  predicate: (entry: JobLogEntry) => boolean,
+  timeoutMs: number = 5_000,
+): Promise<JobLogEntry> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const match = logEntries.find(predicate);
+    if (match !== undefined) {
+      return match;
+    }
+
+    await delay(50);
+  }
+
+  throw new Error("Timed out waiting for expected worker log entry");
+}
+
+async function runSqlStatements(client: Client, sql: string): Promise<void> {
+  const statements = sql
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0);
+
+  for (const statement of statements) {
+    await client.query(statement);
+  }
+}
+
+async function findMigrationFiles(): Promise<string[]> {
+  const entries = await readdir(DRIZZLE_DIRECTORY, { withFileTypes: true });
+
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".sql"))
+    .map((entry) => path.join(DRIZZLE_DIRECTORY, entry.name))
+    .sort();
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/test/helpers/worker-test-runtime.ts
+++ b/test/helpers/worker-test-runtime.ts
@@ -159,12 +159,20 @@ export async function waitForLogEntry(
 }
 
 async function runSqlStatements(client: Client, sql: string): Promise<void> {
-  const statements = sql
-    .split("--> statement-breakpoint")
-    .map((statement) => statement.trim())
-    .filter((statement) => statement.length > 0);
+  const statementBreakpoint = "--> statement-breakpoint";
+  const hasStatementBreakpoint = sql.includes(statementBreakpoint);
+  const executableStatements = hasStatementBreakpoint
+    ? sql
+        .split(statementBreakpoint)
+        .map((statement) => statement.trim())
+        .filter((statement) => statement.length > 0)
+    : sql
+        // TODO: Replace this semicolon fallback with a SQL-aware parser before adding custom migrations.
+        .split(";")
+        .map((statement) => statement.trim())
+        .filter((statement) => statement.length > 0);
 
-  for (const statement of statements) {
+  for (const statement of executableStatements) {
     await client.query(statement);
   }
 }

--- a/test/helpers/worker-test-runtime.ts
+++ b/test/helpers/worker-test-runtime.ts
@@ -191,10 +191,14 @@ function assertSafeTestDatabaseUrl(connectionString: string): void {
 
   const parsed = new URL(connectionString);
   const databaseName = parsed.pathname.replace(/^\//, "");
-  const isLocalhost =
-    parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1";
+  const isAllowedTestHost =
+    parsed.hostname === "localhost" ||
+    parsed.hostname === "127.0.0.1" ||
+    parsed.hostname === "postgres" ||
+    parsed.hostname === "db" ||
+    parsed.hostname === "postgresql";
 
-  if (!isLocalhost || !databaseName.includes("test")) {
+  if (!isAllowedTestHost || !databaseName.includes("test")) {
     throw new Error(
       `Unsafe worker test database target: ${parsed.hostname}/${databaseName}`,
     );

--- a/test/integration/workers/queue-lifecycle.test.ts
+++ b/test/integration/workers/queue-lifecycle.test.ts
@@ -10,10 +10,10 @@ import {
   waitForRun,
 } from "../../helpers/worker-test-runtime.js";
 
-const DATABASE_URL = process.env.DATABASE_URL;
+const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL;
 
 const describeWorkerIntegration =
-  DATABASE_URL === undefined ? describe.skip : describe;
+  TEST_DATABASE_URL === undefined ? describe.skip : describe;
 
 function toJobPayload(runId: string): ReviewJobPayload {
   return {
@@ -71,7 +71,7 @@ describeWorkerIntegration("worker queue lifecycle integration", () => {
     expect(updated.startedAt).toBeDefined();
     expect(updated.completedAt).toBeDefined();
     expect(updated.errorMessage).toBeUndefined();
-  });
+  }, 15_000);
 
   it("retries retryable failures and eventually completes", async () => {
     let executeCalls = 0;
@@ -116,7 +116,7 @@ describeWorkerIntegration("worker queue lifecycle integration", () => {
     expect(executeCalls).toBe(2);
     expect(updated.errorMessage).toBeUndefined();
     expect(updated.completedAt).toBeDefined();
-  });
+  }, 15_000);
 
   it("dead-letters exhausted retryable failures and marks the run failed", async () => {
     let executeCalls = 0;
@@ -159,7 +159,7 @@ describeWorkerIntegration("worker queue lifecycle integration", () => {
 
     expect(executeCalls).toBe(2);
     expect(updated.completedAt).toBeDefined();
-  });
+  }, 15_000);
 
   it("skips idempotently when a queued run is already completed", async () => {
     let executeCalls = 0;
@@ -192,13 +192,15 @@ describeWorkerIntegration("worker queue lifecycle integration", () => {
     const unchanged = await runtime.reviewRunRepository.findById(run.id);
     expect(executeCalls).toBe(0);
     expect(unchanged).toEqual(run);
-  });
+  }, 15_000);
 });
 
 function getDatabaseUrl(): string {
-  if (DATABASE_URL === undefined) {
-    throw new Error("DATABASE_URL must be set for worker integration tests");
+  if (TEST_DATABASE_URL === undefined) {
+    throw new Error(
+      "TEST_DATABASE_URL must be set for worker integration tests",
+    );
   }
 
-  return DATABASE_URL;
+  return TEST_DATABASE_URL;
 }

--- a/test/integration/workers/queue-lifecycle.test.ts
+++ b/test/integration/workers/queue-lifecycle.test.ts
@@ -64,7 +64,7 @@ describeWorkerIntegration("worker queue lifecycle integration", () => {
     const updated = await waitForRun(
       runtime.reviewRunRepository,
       run.id,
-      (candidate) => candidate?.status === "completed",
+      (candidate) => candidate.status === "completed",
     );
 
     expect(executeCalls).toBe(1);
@@ -104,7 +104,7 @@ describeWorkerIntegration("worker queue lifecycle integration", () => {
     const updated = await waitForRun(
       runtime.reviewRunRepository,
       run.id,
-      (candidate) => candidate?.status === "completed",
+      (candidate) => candidate.status === "completed",
       10_000,
     );
 
@@ -144,7 +144,7 @@ describeWorkerIntegration("worker queue lifecycle integration", () => {
       runtime.reviewRunRepository,
       run.id,
       (candidate) =>
-        candidate?.status === "failed" &&
+        candidate.status === "failed" &&
         candidate.errorMessage?.includes(
           "dead-lettered after exhausting retries",
         ) === true,

--- a/test/integration/workers/queue-lifecycle.test.ts
+++ b/test/integration/workers/queue-lifecycle.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { FixExecutor } from "../../../src/application/ports/fix-executor.js";
+import type { ReviewJobPayload } from "../../../src/contracts/review-job-payload.js";
+import { createReviewRun } from "../../fixtures/review-run.js";
+import {
+  createWorkerTestRuntime,
+  resetWorkerTestDatabase,
+  type WorkerTestRuntime,
+  waitForLogEntry,
+  waitForRun,
+} from "../../helpers/worker-test-runtime.js";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+
+const describeWorkerIntegration =
+  DATABASE_URL === undefined ? describe.skip : describe;
+
+function toJobPayload(runId: string): ReviewJobPayload {
+  return {
+    headSha: "abc123",
+    pullRequestNumber: 12,
+    repositoryName: "Yamabiko",
+    repositoryOwner: "ToaruPen",
+    runId,
+  };
+}
+
+describeWorkerIntegration("worker queue lifecycle integration", () => {
+  let databaseUrl = "";
+  let runtime: WorkerTestRuntime | null = null;
+
+  beforeEach(async () => {
+    databaseUrl = getDatabaseUrl();
+    await resetWorkerTestDatabase(databaseUrl);
+  });
+
+  afterEach(async () => {
+    if (runtime !== null) {
+      await runtime.stop();
+      runtime = null;
+    }
+  });
+
+  it("processes a queued pending run to completed", async () => {
+    let executeCalls = 0;
+    const fixExecutor: FixExecutor = {
+      execute() {
+        executeCalls += 1;
+        return Promise.resolve({
+          changedFiles: ["src/workers/handle-review-job.ts"],
+          summary: "applied one deterministic fix",
+        });
+      },
+    };
+
+    runtime = await createWorkerTestRuntime(databaseUrl, fixExecutor, {
+      retryDelay: 1,
+    });
+
+    const run = createReviewRun("run-success");
+    await runtime.reviewRunRepository.save(run);
+    await runtime.queue.enqueue(toJobPayload(run.id));
+
+    const updated = await waitForRun(
+      runtime.reviewRunRepository,
+      run.id,
+      (candidate) => candidate?.status === "completed",
+    );
+
+    expect(executeCalls).toBe(1);
+    expect(updated.startedAt).toBeDefined();
+    expect(updated.completedAt).toBeDefined();
+    expect(updated.errorMessage).toBeUndefined();
+  });
+
+  it("retries retryable failures and eventually completes", async () => {
+    let executeCalls = 0;
+    const fixExecutor: FixExecutor = {
+      execute() {
+        executeCalls += 1;
+        if (executeCalls === 1) {
+          return Promise.reject(
+            Object.assign(new Error("temporary network issue"), {
+              code: "ETIMEDOUT",
+            }),
+          );
+        }
+
+        return Promise.resolve({
+          changedFiles: [],
+          summary: "succeeded after retry",
+        });
+      },
+    };
+
+    runtime = await createWorkerTestRuntime(databaseUrl, fixExecutor, {
+      retryDelay: 1,
+    });
+
+    const run = createReviewRun("run-retry");
+    await runtime.reviewRunRepository.save(run);
+    await runtime.queue.enqueue(toJobPayload(run.id));
+
+    const updated = await waitForRun(
+      runtime.reviewRunRepository,
+      run.id,
+      (candidate) => candidate?.status === "completed",
+      10_000,
+    );
+
+    await waitForLogEntry(
+      runtime.logEntries,
+      (entry) => entry.runId === run.id && entry.event === "job.retrying",
+    );
+
+    expect(executeCalls).toBe(2);
+    expect(updated.errorMessage).toBeUndefined();
+    expect(updated.completedAt).toBeDefined();
+  });
+
+  it("dead-letters exhausted retryable failures and marks the run failed", async () => {
+    let executeCalls = 0;
+    const fixExecutor: FixExecutor = {
+      execute() {
+        executeCalls += 1;
+        return Promise.reject(
+          Object.assign(new Error("transient upstream outage"), {
+            code: "ECONNRESET",
+          }),
+        );
+      },
+    };
+
+    runtime = await createWorkerTestRuntime(databaseUrl, fixExecutor, {
+      retryDelay: 1,
+      retryLimit: 1,
+    });
+
+    const run = createReviewRun("run-dead-letter");
+    await runtime.reviewRunRepository.save(run);
+    await runtime.queue.enqueue(toJobPayload(run.id));
+
+    const updated = await waitForRun(
+      runtime.reviewRunRepository,
+      run.id,
+      (candidate) =>
+        candidate?.status === "failed" &&
+        candidate.errorMessage?.includes(
+          "dead-lettered after exhausting retries",
+        ) === true,
+      10_000,
+    );
+
+    await waitForLogEntry(
+      runtime.logEntries,
+      (entry) => entry.runId === run.id && entry.event === "job.dead_lettered",
+      10_000,
+    );
+
+    expect(executeCalls).toBe(2);
+    expect(updated.completedAt).toBeDefined();
+  });
+
+  it("skips idempotently when a queued run is already completed", async () => {
+    let executeCalls = 0;
+    const fixExecutor: FixExecutor = {
+      execute() {
+        executeCalls += 1;
+        return Promise.resolve({
+          changedFiles: [],
+          summary: "should never run",
+        });
+      },
+    };
+
+    runtime = await createWorkerTestRuntime(databaseUrl, fixExecutor, {
+      retryDelay: 1,
+    });
+
+    const run = createReviewRun("run-terminal", {
+      completedAt: "2026-03-07T12:00:00.000Z",
+      status: "completed",
+    });
+    await runtime.reviewRunRepository.save(run);
+    await runtime.queue.enqueue(toJobPayload(run.id));
+
+    await waitForLogEntry(
+      runtime.logEntries,
+      (entry) => entry.runId === run.id && entry.event === "job.completed",
+    );
+
+    const unchanged = await runtime.reviewRunRepository.findById(run.id);
+    expect(executeCalls).toBe(0);
+    expect(unchanged).toEqual(run);
+  });
+});
+
+function getDatabaseUrl(): string {
+  if (DATABASE_URL === undefined) {
+    throw new Error("DATABASE_URL must be set for worker integration tests");
+  }
+
+  return DATABASE_URL;
+}

--- a/test/unit/adapters/pg-boss-review-job-queue.test.ts
+++ b/test/unit/adapters/pg-boss-review-job-queue.test.ts
@@ -48,6 +48,26 @@ describe("PgBossReviewJobQueue", () => {
     });
   });
 
+  it("createQueue allows retry settings to be overridden", async () => {
+    const bossMock = {
+      send: vi.fn().mockResolvedValue("job-id-1"),
+      createQueue: vi.fn().mockResolvedValue(undefined),
+    };
+    const queue = new PgBossReviewJobQueue(bossMock as unknown as PgBoss, {
+      retryDelay: 1,
+      retryLimit: 1,
+    });
+
+    await queue.createQueue();
+
+    expect(bossMock.createQueue).toHaveBeenNthCalledWith(2, REVIEW_JOBS_QUEUE, {
+      retryLimit: 1,
+      retryDelay: 1,
+      retryBackoff: true,
+      deadLetter: REVIEW_JOBS_DLQ,
+    });
+  });
+
   it("uses constructor injected pg-boss instance", async () => {
     const bossMock = {
       send: vi.fn().mockResolvedValue("job-id-2"),

--- a/test/unit/adapters/pg-boss-review-job-queue.test.ts
+++ b/test/unit/adapters/pg-boss-review-job-queue.test.ts
@@ -60,6 +60,8 @@ describe("PgBossReviewJobQueue", () => {
 
     await queue.createQueue();
 
+    expect(bossMock.createQueue).toHaveBeenCalledTimes(2);
+    expect(bossMock.createQueue).toHaveBeenNthCalledWith(1, REVIEW_JOBS_DLQ);
     expect(bossMock.createQueue).toHaveBeenNthCalledWith(2, REVIEW_JOBS_QUEUE, {
       retryLimit: 1,
       retryDelay: 1,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,24 @@ export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
     reporters: ["default"],
+    coverage: {
+      provider: "v8",
+      reportsDirectory: "coverage",
+      reporter: ["text", "json-summary", "html"],
+      include: [
+        "src/domain/**/*.ts",
+        "src/application/**/*.ts",
+        "src/workers/**/*.ts",
+        "src/contracts/**/*.ts",
+        "src/config/**/*.ts",
+      ],
+      exclude: [
+        "src/**/index.ts",
+        "src/**/*.d.ts",
+        "src/application/ports/**",
+        "src/domain/deliveries/**",
+        "src/domain/review-events/review-feedback-event.ts",
+      ],
+    },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,9 @@ export default defineConfig({
       include: [
         "src/domain/**/*.ts",
         "src/application/**/*.ts",
+        "src/adapters/queue/**/*.ts",
         "src/workers/**/*.ts",
+        "src/entrypoints/worker/**/*.ts",
         "src/contracts/**/*.ts",
         "src/config/**/*.ts",
       ],


### PR DESCRIPTION
## Summary
- extract the pg-boss worker runtime into reusable startup and shutdown helpers so production wiring and tests share the same execution path
- add PostgreSQL-backed worker integration coverage plus report-only coverage tooling for local runs and CI artifacts
- update CI and project docs to reflect the new worker test path, Postgres service requirement, and current phase status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * PostgreSQL対応のワーカーランタイムを導入（ジョブキュー処理、再試行分類、デッドレター、スタール処理回復、実行ライフサイクル管理、ジョブロギング）

* **テスト**
  * ワーカー統合テストを追加（キューライフサイクル、リトライ、デッドレター、冪等性）
  * カバレッジ出力とカバレッジ用テストスクリプトを追加

* **ドキュメント**
  * セットアップ／実行手順とフェーズ説明を更新（ワーカーとテストの条件を明記）

* **その他**
  * CIにPostgres設定とカバレッジ収集・アーティファクトアップロードを追加、ツールの対象ファイル選定を調整
<!-- end of auto-generated comment: release notes by coderabbit.ai -->